### PR TITLE
Add support for alternate diff highlight groups

### DIFF
--- a/colors/alduin.vim
+++ b/colors/alduin.vim
@@ -128,6 +128,18 @@ highlight DiffAdd guifg=#008787 guibg=NONE gui=reverse ctermfg=30 ctermbg=NONE c
 highlight DiffText guifg=#008787 guibg=NONE gui=reverse ctermfg=30 ctermbg=NONE cterm=reverse
 highlight DiffChange guifg=#005f5f guibg=NONE gui=reverse ctermfg=23 ctermbg=NONE cterm=reverse
 highlight DiffDelete guifg=#af5f5f guibg=NONE gui=reverse ctermfg=131 ctermbg=NONE cterm=reverse
+hi! link diffAdded DiffAdd
+hi! link diffBDiffer WarningMsg
+hi! link diffChanged DiffChange
+hi! link diffCommon WarningMsg
+hi! link diffDiffer WarningMsg
+hi! link diffFile Directory
+hi! link diffIdentical WarningMsg
+hi! link diffIndexLine Number
+hi! link diffIsA WarningMsg
+hi! link diffNoEOL WarningMsg
+hi! link diffOnly WarningMsg
+hi! link diffRemoved DiffDelete
 
 "SPELLING
 highlight SpellBad guifg=#ff0000 guibg=NONE gui=undercurl ctermfg=196 ctermbg=NONE cterm=undercurl

--- a/colors/alduin.vim
+++ b/colors/alduin.vim
@@ -128,18 +128,18 @@ highlight DiffAdd guifg=#008787 guibg=NONE gui=reverse ctermfg=30 ctermbg=NONE c
 highlight DiffText guifg=#008787 guibg=NONE gui=reverse ctermfg=30 ctermbg=NONE cterm=reverse
 highlight DiffChange guifg=#005f5f guibg=NONE gui=reverse ctermfg=23 ctermbg=NONE cterm=reverse
 highlight DiffDelete guifg=#af5f5f guibg=NONE gui=reverse ctermfg=131 ctermbg=NONE cterm=reverse
-hi! link diffAdded DiffAdd
-hi! link diffBDiffer WarningMsg
-hi! link diffChanged DiffChange
-hi! link diffCommon WarningMsg
-hi! link diffDiffer WarningMsg
-hi! link diffFile Directory
-hi! link diffIdentical WarningMsg
-hi! link diffIndexLine Number
-hi! link diffIsA WarningMsg
-hi! link diffNoEOL WarningMsg
-hi! link diffOnly WarningMsg
-hi! link diffRemoved DiffDelete
+highlight link diffAdded DiffAdd
+highlight link diffBDiffer WarningMsg
+highlight link diffChanged DiffChange
+highlight link diffCommon WarningMsg
+highlight link diffDiffer WarningMsg
+highlight link diffFile Directory
+highlight link diffIdentical WarningMsg
+highlight link diffIndexLine Number
+highlight link diffIsA WarningMsg
+highlight link diffNoEOL WarningMsg
+highlight link diffOnly WarningMsg
+highlight link diffRemoved DiffDelete
 
 "SPELLING
 highlight SpellBad guifg=#ff0000 guibg=NONE gui=undercurl ctermfg=196 ctermbg=NONE cterm=undercurl


### PR DESCRIPTION
Hi,

let me just say that I love this colour scheme, you’ve done a great job with it! I have noticed, however, that the diff highlighting can be a little inconsistent. After poking around a bit I discovered that Vim has not one, but *two* sets of diff highlight groups. This pull request adds the second set.

Thanks.