### PR TITLE
Add NormalFloat for hover windows used in plugins like COC

### DIFF
--- a/colors/alduin.vim
+++ b/colors/alduin.vim
@@ -133,6 +133,8 @@ highlight PreCondit guifg=#dfaf87 guibg=NONE gui=NONE ctermfg=180 ctermbg=NONE c
 highlight IncSearch guifg=#af5f5f guibg=NONE gui=reverse ctermfg=131 ctermbg=NONE cterm=reverse
 highlight VisualNOS guifg=NONE guibg=NONE gui=underline ctermfg=NONE ctermbg=NONE cterm=underline
 
+highlight NormalFloat guifg=#ffdf87 guibg=#262626 gui=NONE ctermfg=222 ctermbg=235 cterm=NONE
+
 "DIFF
 highlight DiffAdd guifg=#008787 guibg=NONE gui=reverse ctermfg=30 ctermbg=NONE cterm=reverse
 highlight DiffText guifg=#008787 guibg=NONE gui=reverse ctermfg=30 ctermbg=NONE cterm=reverse
@@ -170,7 +172,7 @@ if 1
 	highlight StatusLineTerm guifg=#9e9e9e guibg=#121212 gui=NONE ctermfg=247 ctermbg=233 cterm=NONE
 	highlight StatusLineTermNC guifg=#6c6c6c guibg=#121212 gui=NONE ctermfg=242 ctermbg=233 cterm=NONE
 
-	highlight Pmenu guifg=#626262 guibg=#262626 gui=NONE ctermfg=241 ctermbg=235 cterm=NONE
+	highlight Pmenu guifg=#dfdfaf guibg=#262626 gui=NONE ctermfg=241 ctermbg=235 cterm=NONE
 	highlight PmenuSbar guifg=#262626 guibg=#262626 gui=NONE ctermfg=235 ctermbg=235 cterm=NONE
 	highlight PmenuThumb guifg=#262626 guibg=#262626 gui=NONE ctermfg=235 ctermbg=235 cterm=NONE
 	highlight TabLineSel guifg=#9e9e9e guibg=#121212 gui=NONE ctermfg=247 ctermbg=233 cterm=NONE


### PR DESCRIPTION
I like this color scheme but haven't been using it because I use COC which shows Intellisense like messages in a Float window. The Float Window's normal bg color is the same as the normal background, so it was hard to tell if a float window was even on screen. I also changed the PMenu font to be more readable in NormalFloat areas, since it was a bit dark with my change.